### PR TITLE
fix: Mobile-optimize Market Scanner and Arena frontends

### DIFF
--- a/public/arena.html
+++ b/public/arena.html
@@ -170,31 +170,34 @@ body::before {
   text-decoration: none;
   white-space: nowrap;
 }
-.btn:hover {
-  border-color: var(--border-hover);
-  color: var(--text-primary);
-  background: var(--bg-card-hover);
-  box-shadow: var(--shadow-card);
+@media (hover: hover) {
+  .btn:hover {
+    border-color: var(--border-hover);
+    color: var(--text-primary);
+    background: var(--bg-card-hover);
+    box-shadow: var(--shadow-card);
+  }
+  .btn-danger:hover {
+    border-color: rgba(220,38,38,0.3);
+    color: var(--red);
+    background: var(--red-dim);
+  }
+  .btn-primary:hover {
+    background: #333;
+    border-color: #333;
+    color: #fff;
+  }
 }
+.btn:active { opacity: 0.7; }
 .btn-danger {
   border-color: rgba(220,38,38,0.15);
   color: rgba(220,38,38,0.7);
   background: transparent;
 }
-.btn-danger:hover {
-  border-color: rgba(220,38,38,0.3);
-  color: var(--red);
-  background: var(--red-dim);
-}
 .btn-primary {
   border-color: var(--accent);
   color: #fff;
   background: var(--accent);
-}
-.btn-primary:hover {
-  background: #333;
-  border-color: #333;
-  color: #fff;
 }
 .btn-back {
   border-color: var(--border);
@@ -222,7 +225,9 @@ body::before {
   transition: background 180ms var(--ease);
 }
 .stat-card:first-child .stat-value { color: var(--text-primary); }
-.stat-card:hover { background: var(--bg-card-hover); }
+@media (hover: hover) {
+  .stat-card:hover { background: var(--bg-card-hover); }
+}
 .stats-bar { box-shadow: var(--shadow-card); }
 .stat-label {
   font-family: var(--sans);
@@ -277,7 +282,7 @@ body::before {
 /* ── Leaderboard ── */
 .leaderboard {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 360px), 1fr));
   gap: 16px;
   margin-bottom: 48px;
 }
@@ -302,12 +307,15 @@ body::before {
   opacity: 0.7;
   transition: opacity 200ms var(--ease);
 }
-.bot-card:hover {
-  border-color: var(--border-hover);
-  box-shadow: var(--shadow-card-hover);
-  transform: translateY(-3px);
+@media (hover: hover) {
+  .bot-card:hover {
+    border-color: var(--border-hover);
+    box-shadow: var(--shadow-card-hover);
+    transform: translateY(-3px);
+  }
+  .bot-card:hover::before { opacity: 1; }
 }
-.bot-card:hover::before { opacity: 1; }
+.bot-card:active { transform: scale(0.99); }
 .bot-card-header {
   display: flex;
   align-items: flex-start;
@@ -450,7 +458,7 @@ body::before {
   z-index: 1;
 }
 .live-feed-scroll {
-  max-height: 560px;
+  max-height: clamp(250px, 60vh, 560px);
   overflow-y: auto;
   overscroll-behavior: contain;
   position: relative;
@@ -469,7 +477,9 @@ body::before {
   opacity: 0.85;
   transition: opacity 180ms var(--ease);
 }
-.feed-trade:hover::before { opacity: 1; }
+@media (hover: hover) {
+  .feed-trade:hover::before { opacity: 1; }
+}
 .feed-trade:nth-child(even) .feed-trade-top { background: rgba(0,0,0,0.012); }
 .feed-trade:last-child { border-bottom: none; }
 .feed-trade-top {
@@ -480,7 +490,9 @@ body::before {
   cursor: pointer;
   transition: background 180ms var(--ease);
 }
-.feed-trade-top:hover { background: rgba(0,0,0,0.015); }
+@media (hover: hover) {
+  .feed-trade-top:hover { background: rgba(0,0,0,0.015); }
+}
 .feed-trade-body {
   display: none;
   padding: 0 16px 14px 88px;
@@ -702,7 +714,9 @@ body::before {
   padding: 16px 20px;
   transition: background 180ms var(--ease);
 }
-.metric-card:hover { background: var(--bg-card-hover); }
+@media (hover: hover) {
+  .metric-card:hover { background: var(--bg-card-hover); }
+}
 .metric-card .metric-label {
   font-family: var(--sans);
   font-size: 10px;
@@ -792,7 +806,9 @@ body::before {
   vertical-align: middle;
 }
 .data-table tr:last-child td { border-bottom: none; }
-.data-table tr:hover td { background: rgba(0,0,0,0.015); }
+@media (hover: hover) {
+  .data-table tr:hover td { background: rgba(0,0,0,0.015); }
+}
 .market-link {
   color: var(--text-primary);
   text-decoration: none;
@@ -835,7 +851,9 @@ body::before {
 .trade-history-card.win::before { background: var(--green); }
 .trade-history-card.loss::before { background: var(--red); }
 .trade-history-card.open::before { background: var(--amber); }
-.trade-history-card:hover { border-color: var(--border-hover); }
+@media (hover: hover) {
+  .trade-history-card:hover { border-color: var(--border-hover); }
+}
 .trade-card-top {
   display: flex;
   align-items: flex-start;
@@ -992,9 +1010,10 @@ body::before {
   .metrics-row { grid-template-columns: repeat(2, 1fr); }
   .data-table { font-size: 11px; }
   .data-table th, .data-table td { padding: 8px 12px; }
-  .header { flex-direction: column; padding-top: 20px; }
+  .header { flex-direction: column; padding-top: 20px; gap: 10px; }
   .detail-header { flex-direction: column; }
   .chart-canvas-wrap { height: 200px; }
+  .btn { padding: 10px 16px; min-height: 44px; }
 }
 @media (max-width: 480px) {
   .stats-bar { grid-template-columns: 1fr 1fr; }

--- a/public/index.html
+++ b/public/index.html
@@ -174,10 +174,12 @@ body::before {
   border: 1px solid var(--border);
   transition: all 180ms var(--ease);
 }
-.arena-link:hover {
-  border-color: var(--border-hover);
-  color: var(--text-primary);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+@media (hover: hover) {
+  .arena-link:hover {
+    border-color: var(--border-hover);
+    color: var(--text-primary);
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
 }
 .refresh-btn {
   font-family: var(--sans);
@@ -194,8 +196,10 @@ body::before {
   align-items: center;
   gap: 6px;
 }
-.refresh-btn:hover { background: #333; border-color: #333; }
-.refresh-btn:active { transform: scale(0.98); }
+@media (hover: hover) {
+  .refresh-btn:hover { background: #333; border-color: #333; }
+}
+.refresh-btn:active { opacity: 0.7; transform: scale(0.98); }
 .refresh-btn.loading { opacity: 0.5; pointer-events: none; }
 .refresh-btn .spinner {
   width: 14px; height: 14px;
@@ -236,7 +240,9 @@ body::before {
   transition: background 180ms var(--ease);
 }
 .stat-item:first-child .stat-value { color: var(--text-primary); }
-.stat-item:hover { background: var(--bg-card-hover); }
+@media (hover: hover) {
+  .stat-item:hover { background: var(--bg-card-hover); }
+}
 .stat-label {
   font-size: 11px;
   color: var(--text-muted);
@@ -247,7 +253,7 @@ body::before {
 }
 .stat-value {
   font-family: var(--mono);
-  font-size: clamp(20px, 2.2vw, 30px);
+  font-size: clamp(16px, 2.2vw, 30px);
   font-weight: 700;
   color: var(--text-primary);
   letter-spacing: -0.02em;
@@ -312,7 +318,10 @@ body::before {
   transition: all 180ms var(--ease);
   white-space: nowrap;
 }
-.filter-btn:hover { color: var(--text-primary); background: var(--bg-surface); border-color: rgba(0,0,0,0.1); }
+@media (hover: hover) {
+  .filter-btn:hover { color: var(--text-primary); background: var(--bg-surface); border-color: rgba(0,0,0,0.1); }
+}
+.filter-btn:active { background: var(--bg-surface); }
 .filter-btn.active {
   background: var(--bg-surface);
   color: var(--text-primary);
@@ -336,16 +345,16 @@ body::before {
   background-position: right 10px center;
   transition: all 180ms var(--ease);
 }
-.sort-select:hover { border-color: var(--border-hover); }
+@media (hover: hover) {
+  .sort-select:hover { border-color: var(--border-hover); }
+}
 
 /* ── Grid ── */
 .card-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 420px), 1fr));
   gap: 20px;
 }
-@media (max-width: 1100px) { .card-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 680px) { .card-grid { grid-template-columns: 1fr; } }
 
 /* ── Card ── */
 .card {
@@ -358,11 +367,14 @@ body::before {
   animation: cardFadeIn 0.4s var(--ease) forwards;
   box-shadow: var(--shadow-card);
 }
-.card:hover {
-  border-color: var(--border-hover);
-  box-shadow: var(--shadow-card-hover);
-  transform: translateY(-3px);
+@media (hover: hover) {
+  .card:hover {
+    border-color: var(--border-hover);
+    box-shadow: var(--shadow-card-hover);
+    transform: translateY(-3px);
+  }
 }
+.card:active { transform: scale(0.99); }
 .card.severity-critical { border-left: 3px solid var(--red); }
 .card.severity-high { border-left: 3px solid rgba(220,38,38,0.4); }
 .card.severity-medium { border-left: 3px solid rgba(217,119,6,0.3); }
@@ -530,7 +542,7 @@ body::before {
 }
 .disc-value {
   font-family: var(--mono);
-  font-size: 30px;
+  font-size: clamp(20px, 5vw, 30px);
   font-weight: 700;
   line-height: 1;
   letter-spacing: -0.03em;
@@ -589,7 +601,10 @@ body::before {
   transition: all 180ms var(--ease);
   gap: 4px;
 }
-.card-expand-btn:hover { background: var(--bg-surface); color: var(--text-secondary); }
+@media (hover: hover) {
+  .card-expand-btn:hover { background: var(--bg-surface); color: var(--text-secondary); }
+}
+.card-expand-btn:active { background: var(--bg-surface); }
 .card-expand-btn .chevron {
   display: inline-block;
   transition: transform 300ms var(--ease);
@@ -776,17 +791,20 @@ body::before {
   .header { gap: 10px; padding-top: 20px; }
   .stats-bar { grid-template-columns: repeat(3, 1fr); gap: 1px; }
   .stat-item { padding: 14px 16px; }
-  .stat-value { font-size: 18px; }
-  .filter-bar { padding: 10px 12px; gap: 8px; }
+  .filter-bar { padding: 10px 12px; gap: 6px 8px; }
   .filter-sep { display: none; }
+  .filter-group { margin-bottom: 4px; }
+  .filter-group:last-child { margin-bottom: 0; }
+  .filter-btn { padding: 8px 12px; min-height: 44px; display: inline-flex; align-items: center; justify-content: center; }
+  .sort-select { padding: 8px 28px 8px 12px; min-height: 44px; }
+  .footer { margin-top: 40px; }
 }
 @media (max-width: 600px) {
   .stats-bar { grid-template-columns: repeat(2, 1fr); }
 }
 @media (max-width: 480px) {
   .header-title { font-size: 16px; }
-  .stat-item { min-width: 0; }
-  .disc-value { font-size: 22px; }
+  .stat-item { min-width: 0; padding: 10px 12px; }
 }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- **Intrinsic card grid** — replaces hardcoded 3-col + breakpoint overrides with `auto-fill/minmax(min(100%, 420px), 1fr)`
- **Hover scoping** — all interactive `:hover` rules wrapped in `@media (hover: hover)` with `:active` fallbacks for touch devices
- **clamp() font sizes** — `.disc-value` and `.stat-value` use `clamp()` instead of fixed sizes + breakpoint overrides
- **44px touch targets** — filter buttons, sort select, and arena buttons get comfortable tap sizing at mobile breakpoints
- **Leaderboard grid fix** — `minmax(min(100%, 360px), 1fr)` prevents overflow at 320px
- **Live feed clamp** — `max-height: clamp(250px, 60vh, 560px)` adapts to small viewports
- **Design review polish** — filter group spacing, stats bar cell tightening at 480px, footer margin

## Testing
- Verified at 320px, 375px, 390px viewport widths using Playwright screenshots
- No horizontal overflow at any width
- Design review scored 91/100 (index.html) and 92/100 (arena.html)

## Files
| File | Changes |
|------|---------|
| `public/index.html` | Intrinsic card grid, clamp() fonts, hover scoping, touch targets, filter group spacing |
| `public/arena.html` | Live feed clamp, leaderboard grid fix, hover scoping, button touch targets |

🤖 Generated with [Claude Code](https://claude.com/claude-code)