### PR TITLE
Fix Kalshi ingest fallback and surface bot thinking cycles

### DIFF
--- a/api/test_kalshi_parser.py
+++ b/api/test_kalshi_parser.py
@@ -1,0 +1,286 @@
+"""
+Tests for Kalshi market price extraction.
+
+Covers the field-fallback chain in extract_kalshi_yes_pct() and
+the end-to-end fetch_kalshi_markets() with representative fixtures.
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+# Ensure api/ is importable
+sys.path.insert(0, os.path.dirname(__file__))
+
+from scanner import extract_kalshi_yes_pct, safe_float
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for extract_kalshi_yes_pct
+# ---------------------------------------------------------------------------
+
+class TestExtractKalshiYesPct(unittest.TestCase):
+    """Unit tests for the price-extraction helper."""
+
+    # ── yes_price present ─────────────────────────────────────────────────
+
+    def test_yes_price_cents(self):
+        """yes_price in cents (e.g. 42) → 42."""
+        m = {"yes_price": 42}
+        self.assertEqual(extract_kalshi_yes_pct(m), 42)
+
+    def test_yes_price_float_cents(self):
+        """yes_price as float cents (e.g. 42.5) → 42.5."""
+        m = {"yes_price": 42.5}
+        self.assertEqual(extract_kalshi_yes_pct(m), 42.5)
+
+    def test_yes_price_dollar_fraction(self):
+        """yes_price in dollar notation 0.42 → 42."""
+        m = {"yes_price": 0.42}
+        self.assertAlmostEqual(extract_kalshi_yes_pct(m), 42, places=1)
+
+    def test_yes_price_zero_is_not_valid(self):
+        """yes_price=0 should fall through to next fallback."""
+        m = {"yes_price": 0, "yes_ask": 55}
+        # Should NOT return 0; should fall through to yes_ask
+        result = extract_kalshi_yes_pct(m)
+        self.assertGreater(result, 0)
+
+    def test_yes_price_string(self):
+        """yes_price as string '65' → 65."""
+        m = {"yes_price": "65"}
+        self.assertEqual(extract_kalshi_yes_pct(m), 65)
+
+    # ── bid/ask both present ──────────────────────────────────────────────
+
+    def test_both_bid_ask(self):
+        """Both yes_bid and yes_ask present → midpoint."""
+        m = {"yes_bid": 40, "yes_ask": 50}
+        self.assertEqual(extract_kalshi_yes_pct(m), 45)
+
+    def test_both_bid_ask_dollars(self):
+        """Both bid/ask in dollar notation → midpoint in cents."""
+        m = {"yes_bid": 0.40, "yes_ask": 0.50}
+        self.assertAlmostEqual(extract_kalshi_yes_pct(m), 45, places=1)
+
+    # ── one-sided book (THE BUG) ──────────────────────────────────────────
+
+    def test_bid_zero_ask_present(self):
+        """yes_bid=0, yes_ask=55 → should use ask (the critical bug case)."""
+        m = {"yes_bid": 0, "yes_ask": 55}
+        result = extract_kalshi_yes_pct(m)
+        self.assertGreater(result, 0)
+        # With only ask available, we use the ask directly
+        self.assertEqual(result, 55)
+
+    def test_bid_present_ask_zero(self):
+        """yes_bid=30, yes_ask=0 → should use bid."""
+        m = {"yes_bid": 30, "yes_ask": 0}
+        result = extract_kalshi_yes_pct(m)
+        self.assertEqual(result, 30)
+
+    def test_bid_present_ask_missing(self):
+        """yes_bid=30, no yes_ask key → should use bid."""
+        m = {"yes_bid": 30}
+        result = extract_kalshi_yes_pct(m)
+        self.assertEqual(result, 30)
+
+    def test_bid_missing_ask_present(self):
+        """no yes_bid key, yes_ask=55 → should use ask."""
+        m = {"yes_ask": 55}
+        result = extract_kalshi_yes_pct(m)
+        self.assertEqual(result, 55)
+
+    # ── last_price fallback ───────────────────────────────────────────────
+
+    def test_last_price_fallback(self):
+        """No bid/ask/yes_price → last_price should be used."""
+        m = {"last_price": 72}
+        self.assertEqual(extract_kalshi_yes_pct(m), 72)
+
+    def test_last_price_dollar(self):
+        """last_price in dollar notation → converted to cents."""
+        m = {"last_price": 0.72}
+        self.assertAlmostEqual(extract_kalshi_yes_pct(m), 72, places=1)
+
+    # ── dollar-denominated field variants ─────────────────────────────────
+
+    def test_yes_price_dollar_field(self):
+        """Explicit 'yes_price_dollar' field → cents."""
+        m = {"yes_price_dollar": 0.55}
+        self.assertAlmostEqual(extract_kalshi_yes_pct(m), 55, places=1)
+
+    def test_last_price_dollar_field(self):
+        """Explicit 'last_price_dollar' field → cents."""
+        m = {"last_price_dollar": 0.33}
+        self.assertAlmostEqual(extract_kalshi_yes_pct(m), 33, places=1)
+
+    # ── validation: out-of-range prices ───────────────────────────────────
+
+    def test_negative_price_returns_none(self):
+        """Negative yes_price → None (invalid)."""
+        m = {"yes_price": -5}
+        self.assertIsNone(extract_kalshi_yes_pct(m))
+
+    def test_over_100_returns_none(self):
+        """yes_price > 100 → None (invalid, unless dollar normalization applies)."""
+        m = {"yes_price": 150}
+        self.assertIsNone(extract_kalshi_yes_pct(m))
+
+    def test_exactly_zero_all_fields_returns_none(self):
+        """All fields zero → None."""
+        m = {"yes_price": 0, "yes_bid": 0, "yes_ask": 0, "last_price": 0}
+        self.assertIsNone(extract_kalshi_yes_pct(m))
+
+    def test_empty_market_returns_none(self):
+        """No relevant fields → None."""
+        m = {"ticker": "FOO", "title": "Something"}
+        self.assertIsNone(extract_kalshi_yes_pct(m))
+
+    # ── edge cases ────────────────────────────────────────────────────────
+
+    def test_none_values_everywhere(self):
+        """All price fields explicitly None → None."""
+        m = {"yes_price": None, "yes_bid": None, "yes_ask": None, "last_price": None}
+        self.assertIsNone(extract_kalshi_yes_pct(m))
+
+    def test_non_numeric_strings(self):
+        """Non-numeric strings → None."""
+        m = {"yes_price": "N/A", "yes_bid": "---"}
+        self.assertIsNone(extract_kalshi_yes_pct(m))
+
+    def test_yes_price_preferred_over_bid_ask(self):
+        """When yes_price and bid/ask both exist, yes_price wins."""
+        m = {"yes_price": 60, "yes_bid": 40, "yes_ask": 50}
+        self.assertEqual(extract_kalshi_yes_pct(m), 60)
+
+
+# ---------------------------------------------------------------------------
+# Integration test: fetch_kalshi_markets with fixture data
+# ---------------------------------------------------------------------------
+
+# Representative fixture mimicking real Kalshi API responses
+KALSHI_FIXTURE = {
+    "markets": [
+        # Case 1: yes_price present (normal)
+        {"ticker": "MKT-A", "title": "Market A", "event_ticker": "EVT-A",
+         "yes_price": 65, "volume": 1000, "open_interest": 500,
+         "category": "Politics", "close_time": "2026-06-01T00:00:00Z"},
+
+        # Case 2: both bid and ask
+        {"ticker": "MKT-B", "title": "Market B", "event_ticker": "EVT-B",
+         "yes_bid": 40, "yes_ask": 50, "volume": 800, "open_interest": 300,
+         "category": "Economics", "close_time": "2026-07-01T00:00:00Z"},
+
+        # Case 3: one-sided book — bid=0, ask present (THE BUG)
+        {"ticker": "MKT-C", "title": "Market C", "event_ticker": "EVT-C",
+         "yes_bid": 0, "yes_ask": 72, "volume": 200, "open_interest": 100,
+         "category": "Tech", "close_time": "2026-08-01T00:00:00Z"},
+
+        # Case 4: only last_price
+        {"ticker": "MKT-D", "title": "Market D", "event_ticker": "EVT-D",
+         "last_price": 55, "volume": 150, "open_interest": 80,
+         "category": "Sports", "close_time": "2026-09-01T00:00:00Z"},
+
+        # Case 5: dollar-denominated yes_price (0.42)
+        {"ticker": "MKT-E", "title": "Market E", "event_ticker": "EVT-E",
+         "yes_price": 0.42, "volume": 500, "open_interest": 200,
+         "category": "Other", "close_time": "2026-10-01T00:00:00Z"},
+
+        # Case 6: completely empty book — should be excluded
+        {"ticker": "MKT-F", "title": "Market F", "event_ticker": "EVT-F",
+         "volume": 50, "open_interest": 10,
+         "category": "Other", "close_time": "2026-11-01T00:00:00Z"},
+    ],
+    "cursor": "",
+}
+
+
+class TestFetchKalshiMarketsIntegration(unittest.TestCase):
+    """Integration tests that mock the HTTP layer and verify market parsing."""
+
+    def _mock_fetch(self, fixture):
+        """Patch fetch_json to return fixture data."""
+        return patch("scanner.fetch_json", return_value=fixture)
+
+    def test_nonzero_markets_from_sparse_data(self):
+        """fetch_kalshi_markets returns non-zero valid markets from sparse fixtures."""
+        from scanner import fetch_kalshi_markets
+        with self._mock_fetch(KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        # Should accept cases 1-5, reject case 6
+        self.assertGreaterEqual(len(markets), 5)
+
+    def test_one_sided_book_included(self):
+        """Market with bid=0, ask=72 must NOT be dropped."""
+        from scanner import fetch_kalshi_markets
+        with self._mock_fetch(KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        tickers = [m.get("ticker") for m in markets]
+        self.assertIn("MKT-C", tickers, "One-sided book market was incorrectly dropped")
+
+    def test_last_price_fallback_included(self):
+        """Market with only last_price must be included."""
+        from scanner import fetch_kalshi_markets
+        with self._mock_fetch(KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        tickers = [m.get("ticker") for m in markets]
+        self.assertIn("MKT-D", tickers, "last_price fallback market was incorrectly dropped")
+
+    def test_dollar_price_normalized(self):
+        """Market with yes_price=0.42 should have yes_price around 42 (cents)."""
+        from scanner import fetch_kalshi_markets
+        with self._mock_fetch(KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        mkt_e = next((m for m in markets if m.get("ticker") == "MKT-E"), None)
+        self.assertIsNotNone(mkt_e, "Dollar-notation market was dropped")
+        self.assertAlmostEqual(mkt_e["yes_price"], 42, delta=1)
+
+    def test_empty_book_excluded(self):
+        """Market with no price fields should be excluded."""
+        from scanner import fetch_kalshi_markets
+        with self._mock_fetch(KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        tickers = [m.get("ticker") for m in markets]
+        self.assertNotIn("MKT-F", tickers, "Empty-book market should have been excluded")
+
+    def test_all_prices_in_valid_range(self):
+        """Every accepted market must have yes_price in (0, 100]."""
+        from scanner import fetch_kalshi_markets
+        with self._mock_fetch(KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        for m in markets:
+            self.assertGreater(m["yes_price"], 0, f"{m['ticker']} has yes_price <= 0")
+            self.assertLessEqual(m["yes_price"], 100, f"{m['ticker']} has yes_price > 100")
+
+
+# Also test bots.py's copy of fetch_kalshi_markets
+class TestBotsKalshiIntegration(unittest.TestCase):
+    """Verify bots.py fetch_kalshi_markets also works with sparse data."""
+
+    def test_nonzero_markets_bots(self):
+        from bots import fetch_kalshi_markets
+        with patch("bots.fetch_json", return_value=KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        # Should accept cases 1-5, reject case 6
+        self.assertGreaterEqual(len(markets), 5)
+
+    def test_one_sided_book_bots(self):
+        from bots import fetch_kalshi_markets
+        with patch("bots.fetch_json", return_value=KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        tickers = [m.get("ticker") for m in markets]
+        self.assertIn("MKT-C", tickers, "bots.py: one-sided book market was dropped")
+
+    def test_prices_in_valid_range_bots(self):
+        from bots import fetch_kalshi_markets
+        with patch("bots.fetch_json", return_value=KALSHI_FIXTURE):
+            markets = fetch_kalshi_markets()
+        for m in markets:
+            self.assertGreater(m["yes_pct"], 0, f"bots.py: {m['ticker']} has yes_pct <= 0")
+            self.assertLessEqual(m["yes_pct"], 100, f"bots.py: {m['ticker']} has yes_pct > 100")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/public/arena.html
+++ b/public/arena.html
@@ -539,6 +539,48 @@ body::before {
   color: var(--text-primary);
 }
 
+/* ── Thinking Cycles ── */
+.cycle-feed-container {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-card);
+}
+.cycle-feed-scroll {
+  max-height: 360px;
+  overflow-y: auto;
+}
+.cycle-row {
+  border-bottom: 1px solid var(--border);
+  padding: 12px 16px;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  animation: slideIn 260ms var(--ease) both;
+}
+.cycle-row:last-child { border-bottom: none; }
+.decision-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.decision-trade { background: var(--green-dim); color: var(--green); }
+.decision-hold { background: var(--amber-dim); color: var(--amber); }
+.reason-pill {
+  display: inline-flex;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
 /* ── Direction Badges ── */
 .dir-badge {
   display: inline-flex;
@@ -1233,6 +1275,7 @@ function renderArena(data) {
   const best = bots[0];
   const totalMarkets = data.totalMarkets || 0;
   const recentTrades = data.recentTrades || [];
+  const latestCycles = bots.map(b => ({ ...(b.latest_cycle || {}), bot_id: b.id })).filter(c => c && c.cycle_timestamp);
 
   return `
   ${renderHeader(data)}
@@ -1279,6 +1322,19 @@ function renderArena(data) {
       ${recentTrades.length === 0
         ? '<div class="status-msg"><span style="color:var(--text-muted)">No trades yet — bots are scanning markets...</span></div>'
         : recentTrades.slice(0, 50).map(t => renderTradeRow(t, bots)).join('')}
+    </div>
+  </div>
+
+  <div class="section-header" style="margin-top:22px">
+    <span class="section-title">Thinking Cycles</span>
+    <div style="height:1px;flex:1;background:rgba(0,0,0,0.08);margin-left:8px"></div>
+    <span style="font-family:var(--mono);font-size:11px;color:var(--text-muted)">${latestCycles.length} bots</span>
+  </div>
+  <div class="cycle-feed-container">
+    <div class="cycle-feed-scroll">
+      ${latestCycles.length === 0
+        ? '<div class="status-msg"><span style="color:var(--text-muted)">No cycle data yet</span></div>'
+        : latestCycles.map(c => renderCycleRow(c, bots)).join('')}
     </div>
   </div>`;
 }
@@ -1369,6 +1425,42 @@ function renderTradeRow(trade, bots) {
   </div>`;
 }
 
+function prettyHoldReason(reason) {
+  if (!reason) return 'Unknown';
+  return reason.toLowerCase().split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+}
+
+function renderCycleRow(cycle, bots) {
+  const bot = bots.find(b => b.id === cycle.bot_id) || {};
+  const defaults = BOT_DEFAULTS[cycle.bot_id] || {};
+  const emoji = bot.emoji || defaults.emoji || '🤖';
+  const name = bot.name || cycle.bot_id || 'Bot';
+  const isTrade = String(cycle.decision || '').toUpperCase() === 'TRADE';
+  const topReasons = cycle.top_hold_reasons || [];
+
+  return `<div class="cycle-row">
+    <div style="font-size:20px;line-height:1;padding-top:1px">${emoji}</div>
+    <div style="flex:1;min-width:0">
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+        <span style="font-size:13px;color:var(--text-primary);font-weight:600">${name}</span>
+        <span class="decision-badge ${isTrade ? 'decision-trade' : 'decision-hold'}">${isTrade ? 'TRADE' : 'HOLD'}</span>
+        <span style="font-family:var(--mono);font-size:10px;color:var(--text-muted)">${fmtTime(cycle.cycle_timestamp)}</span>
+      </div>
+      <div style="font-family:var(--mono);font-size:11px;color:var(--text-secondary);margin-top:4px">
+        positions ${cycle.open_positions ?? '—'}/${cycle.max_positions ?? '—'} • candidates ${cycle.candidates_after_filters ?? 0}/${cycle.candidates_scanned ?? 0}
+      </div>
+      ${!isTrade ? `
+        <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap">
+          ${topReasons.length === 0
+            ? '<span class="reason-pill">No hold reason captured</span>'
+            : topReasons.map(r => `<span class="reason-pill">${prettyHoldReason(r.reason)} (${r.count})</span>`).join('')}
+        </div>
+        ${cycle.next_trade_condition ? `<div style="font-size:12px;color:var(--text-secondary);line-height:1.45;margin-top:8px">${cycle.next_trade_condition}</div>` : ''}
+      ` : ''}
+    </div>
+  </div>`;
+}
+
 /* ════════════════════════════════════════
    BOT DETAIL VIEW
    ════════════════════════════════════════ */
@@ -1380,6 +1472,7 @@ function renderBotDetail(bot) {
   const isPositive = equity >= 10000;
   const positions = bot.positions || [];
   const trades = bot.new_trades || bot.trades || [];
+  const cycles = bot.cycle_history || (bot.latest_cycle ? [bot.latest_cycle] : []);
   const params = bot.strategy_params || {};
   const curve = bot.equity_curve || [];
 
@@ -1442,6 +1535,20 @@ function renderBotDetail(bot) {
         : trades.map((t, i) => renderTradeHistoryCard(t, color, i)).join('')}
     </div>
 
+    <!-- Thinking Cycle History -->
+    <div class="section-header" style="margin-top:28px">
+      <span class="section-title">Thinking Cycles</span>
+      <div style="height:1px;flex:1;background:var(--border);margin-left:8px"></div>
+      <span style="font-family:var(--mono);font-size:10px;color:var(--text-muted)">${cycles.length} cycles</span>
+    </div>
+    <div class="cycle-feed-container">
+      <div class="cycle-feed-scroll">
+        ${cycles.length === 0
+          ? '<div class="status-msg"><span style="color:var(--text-muted)">No cycle data yet</span></div>'
+          : cycles.slice(0, 50).map(c => renderCycleHistoryRow(c)).join('')}
+      </div>
+    </div>
+
     <!-- Strategy Details -->
     <div class="section-header" style="margin-top:40px">
       <span class="section-title">Strategy Details</span>
@@ -1459,6 +1566,30 @@ function renderBotDetail(bot) {
       </div>` : ''}
     </div>
 
+  </div>`;
+}
+
+function renderCycleHistoryRow(cycle) {
+  const isTrade = String(cycle.decision || '').toUpperCase() === 'TRADE';
+  const reasons = cycle.top_hold_reasons || [];
+  return `<div class="cycle-row">
+    <div style="flex:1;min-width:0">
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+        <span class="decision-badge ${isTrade ? 'decision-trade' : 'decision-hold'}">${isTrade ? 'TRADE' : 'HOLD'}</span>
+        <span style="font-family:var(--mono);font-size:10px;color:var(--text-muted)">${fmtTime(cycle.cycle_timestamp)}</span>
+      </div>
+      <div style="font-family:var(--mono);font-size:11px;color:var(--text-secondary);margin-top:4px">
+        positions ${cycle.open_positions ?? '—'}/${cycle.max_positions ?? '—'} • candidates ${cycle.candidates_after_filters ?? 0}/${cycle.candidates_scanned ?? 0}
+      </div>
+      ${!isTrade ? `
+        <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap">
+          ${reasons.length === 0
+            ? '<span class="reason-pill">No hold reason captured</span>'
+            : reasons.map(r => `<span class="reason-pill">${prettyHoldReason(r.reason)} (${r.count})</span>`).join('')}
+        </div>
+        ${cycle.next_trade_condition ? `<div style="font-size:12px;color:var(--text-secondary);line-height:1.45;margin-top:8px">${cycle.next_trade_condition}</div>` : ''}
+      ` : ''}
+    </div>
   </div>`;
 }
 

--- a/tests/test_issue2_cycles.py
+++ b/tests/test_issue2_cycles.py
@@ -1,0 +1,148 @@
+import unittest
+from unittest.mock import patch
+
+import api.bots as bots
+
+
+def _base_bot(strategy="test_strategy", max_positions=1):
+    return {
+        "id": "testbot",
+        "name": "Test Bot",
+        "strategy": strategy,
+        "strategy_name": "Test Strategy",
+        "title": "Test Title",
+        "personality": "Test",
+        "emoji": "T",
+        "color": "#111111",
+        "accent": "#222222",
+        "params": {"max_positions": max_positions, "kelly_fraction": 0.25},
+    }
+
+
+def _trade(market="Will test happen?"):
+    return {
+        "market": market,
+        "platform": "Polymarket",
+        "url": "https://example.com",
+        "category": "Other",
+        "direction": "BUY_YES",
+        "market_price": 40.0,
+        "estimated_prob": 55.0,
+        "edge_pp": 15.0,
+        "bet_amount": 100.0,
+        "kelly_fraction": 0.25,
+        "source": "Test Source",
+        "rationale": "Test rationale",
+        "confidence": "HIGH",
+    }
+
+
+class ThinkingCyclesTests(unittest.TestCase):
+    def test_run_bot_engine_emits_latest_cycle_for_hold_with_position_cap_reason(self):
+        bot = _base_bot(strategy="test_strategy", max_positions=1)
+        existing_pos = {
+            "trade_id": "p1",
+            "market": "Will test happen?",
+            "direction": "BUY_YES",
+            "entry_price": 40.0,
+            "current_price": 40.0,
+            "bet_amount": 100.0,
+            "timestamp": "2026-02-28T10:00:00Z",
+            "platform": "Polymarket",
+            "url": "https://example.com",
+        }
+        state = {
+            bot["id"]: {
+                "bankroll": 9900.0,
+                "total_trades": 1,
+                "winning_trades": 0,
+                "total_pnl": 0,
+                "peak_bankroll": 10000.0,
+                "positions": [existing_pos],
+                "equity_curve": [{"time": "2026-02-28T10:00:00Z", "value": 10000.0}],
+            }
+        }
+
+        with patch.object(bots, "BOTS", [bot]), \
+             patch.object(bots, "STRATEGY_MAP", {"test_strategy": lambda *args, **kwargs: [_trade()]}), \
+             patch.object(bots, "fetch_polymarket_markets", return_value=[]), \
+             patch.object(bots, "fetch_kalshi_markets", return_value=[]), \
+             patch.object(bots, "load_state", return_value=state), \
+             patch.object(bots, "load_trades", return_value=[]), \
+             patch.object(bots, "save_state"), \
+             patch.object(bots, "save_trades"), \
+             patch.object(bots, "load_cycles", return_value=[]), \
+             patch.object(bots, "save_cycles"):
+            result = bots.run_bot_engine()
+
+        cycle = result["bots"][0]["latest_cycle"]
+        self.assertEqual(cycle["decision"], "HOLD")
+        reasons = {r["reason"] for r in cycle["top_hold_reasons"]}
+        self.assertIn("AT_MAX_POSITIONS", reasons)
+        self.assertIn("recentCycles", result)
+        self.assertGreaterEqual(len(result["recentCycles"]), 1)
+
+    def test_run_bot_engine_emits_dependency_reason_for_arb_bot_when_kalshi_missing(self):
+        bot = _base_bot(strategy="cross_platform_arb", max_positions=2)
+        state = {
+            bot["id"]: {
+                "bankroll": 10000.0,
+                "total_trades": 0,
+                "winning_trades": 0,
+                "total_pnl": 0,
+                "peak_bankroll": 10000.0,
+                "positions": [],
+                "equity_curve": [{"time": "2026-02-28T10:00:00Z", "value": 10000.0}],
+            }
+        }
+
+        with patch.object(bots, "BOTS", [bot]), \
+             patch.object(bots, "STRATEGY_MAP", {"cross_platform_arb": lambda *args, **kwargs: []}), \
+             patch.object(bots, "fetch_polymarket_markets", return_value=[{"title": "X", "yes_pct": 50.0, "volume": 1000, "platform": "Polymarket", "url": "https://example.com"}]), \
+             patch.object(bots, "fetch_kalshi_markets", return_value=[]), \
+             patch.object(bots, "load_state", return_value=state), \
+             patch.object(bots, "load_trades", return_value=[]), \
+             patch.object(bots, "save_state"), \
+             patch.object(bots, "save_trades"), \
+             patch.object(bots, "load_cycles", return_value=[]), \
+             patch.object(bots, "save_cycles"):
+            result = bots.run_bot_engine()
+
+        cycle = result["bots"][0]["latest_cycle"]
+        reasons = {r["reason"] for r in cycle["top_hold_reasons"]}
+        self.assertIn("DEPENDENCY_DATA_UNAVAILABLE", reasons)
+        self.assertEqual(cycle["decision"], "HOLD")
+
+    def test_run_bot_engine_marks_trade_cycle_when_trade_executes(self):
+        bot = _base_bot(strategy="test_strategy", max_positions=2)
+        state = {
+            bot["id"]: {
+                "bankroll": 10000.0,
+                "total_trades": 0,
+                "winning_trades": 0,
+                "total_pnl": 0,
+                "peak_bankroll": 10000.0,
+                "positions": [],
+                "equity_curve": [{"time": "2026-02-28T10:00:00Z", "value": 10000.0}],
+            }
+        }
+
+        with patch.object(bots, "BOTS", [bot]), \
+             patch.object(bots, "STRATEGY_MAP", {"test_strategy": lambda *args, **kwargs: [_trade("Will another test happen?")]}), \
+             patch.object(bots, "fetch_polymarket_markets", return_value=[]), \
+             patch.object(bots, "fetch_kalshi_markets", return_value=[]), \
+             patch.object(bots, "load_state", return_value=state), \
+             patch.object(bots, "load_trades", return_value=[]), \
+             patch.object(bots, "save_state"), \
+             patch.object(bots, "save_trades"), \
+             patch.object(bots, "load_cycles", return_value=[]), \
+             patch.object(bots, "save_cycles"):
+            result = bots.run_bot_engine()
+
+        cycle = result["bots"][0]["latest_cycle"]
+        self.assertEqual(cycle["decision"], "TRADE")
+        self.assertEqual(cycle["top_hold_reasons"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes Kalshi market parsing so sparse and one-sided order books plus fallback price fields no longer get dropped. It adds a robust yes-price extraction path in both scanner and bot ingest, plus cycle persistence and history output (latest_cycle, recentCycles, and action=cycles). It also adds regression tests for Kalshi parsing and cycle metadata emission. Finally, it updates the arena UI to show Thinking Cycles in both the overview feed and bot detail history.